### PR TITLE
Write and test db-connection module

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,41 @@
+const express = require('express');
+// var mongo = require('mongodb');
+const connectDb = require('./db-connection');
+const { logger } = require('./pino');
+const cors = require('cors');
+
+function createApp() {
+  const app = express();
+
+  app.use(cors());
+
+  /** this project needs to parse POST bodies **/
+  // you should mount the body-parser here
+
+  app.use('/public', express.static(process.cwd() + '/public'));
+
+  app.get('/', function(req, res){
+    res.sendFile(process.cwd() + '/views/index.html');
+  });
+
+  app.get("/api/hello", function (req, res) {
+    res.json({greeting: 'hello API'});
+  });
+
+  return app;
+}
+
+function startServer(factory, dbUri, port = process.env.PORT || 3000) {
+  const app = factory();
+  return connectDb(logger, dbUri)
+    .then(() => {
+      return app.listen(port, function () {
+        logger.info('Node.js listening ...');
+      });
+    });
+}
+
+module.exports = {
+  startServer,
+  createApp
+};

--- a/db-connection.js
+++ b/db-connection.js
@@ -1,0 +1,14 @@
+var mongoose = require('mongoose');
+
+function connectDb (logger, dbUri = process.env.DB_URI) {
+    return mongoose.connect(dbUri, { useNewUrlParser: true, useUnifiedTopology: true })
+        .then(function () {
+            logger.info("DB connected successfully.");
+        })
+        .catch(function (error) {
+            logger.fatal(error, "DB failed to connect.");
+            throw(error);
+        });
+}
+
+module.exports = connectDb;

--- a/db-connection.test.js
+++ b/db-connection.test.js
@@ -1,0 +1,36 @@
+const connectDb = require('./db-connection');
+const mongoose = require('mongoose');
+
+// logger stub with spies
+const log = {
+    fatal: jest.fn(),
+    info: jest.fn()
+}
+
+describe("DB connection", () => {
+    // Causes connection to db to fail
+    const DB_URI = '';
+
+    test("fails with invalid uri for db.", () => {
+        expect.assertions(1);
+
+        return connectDb(log, DB_URI)
+            .catch(() => {
+                expect(log.fatal).toBeCalled();
+            });
+    });
+});
+
+describe("DB connection", () => {
+    // MONGO_URL is provided by @shelf/jest-mongodb
+    const DB_URI = process.env.MONGO_URL;
+
+    afterAll(() => {
+        return mongoose.disconnect();
+    });
+
+    test("is succesful.", () => {
+        return connectDb(log, DB_URI)
+            .then(() => expect(log.info).toBeCalled());
+    });
+});

--- a/server.js
+++ b/server.js
@@ -1,45 +1,4 @@
 'use strict';
+const { createApp, startServer } = require('./app');
 
-var express = require('express');
-// var mongo = require('mongodb');
-var mongoose = require('mongoose');
-
-var cors = require('cors');
-var { logger } = require('./pino');
-
-var app = express();
-
-var port = process.env.PORT || 3000;
-
-app.use(cors());
-
-/** this project needs to parse POST bodies **/
-// you should mount the body-parser here
-
-app.use('/public', express.static(process.cwd() + '/public'));
-
-app.get('/', function(req, res){
-  res.sendFile(process.cwd() + '/views/index.html');
-});
-
-app.get("/api/hello", function (req, res) {
-  res.json({greeting: 'hello API'});
-});
-
-const appServer = app.listen(port, function () {
-  console.log('Node.js listening ...');
-});
-
-mongoose.connect(process.env.DB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
-  .then(function () {
-    logger.info("DB connected successfully.");
-  })
-  .catch(function (error) {
-    logger.fatal(error, "DB failed to connect.");
-    appServer.close();
-  });
-
-module.exports = {
-  appServer,
-  mongoose
-};
+startServer(createApp);

--- a/server.test.js
+++ b/server.test.js
@@ -1,12 +1,20 @@
+const { createApp, startServer } = require('./app');
+const mongoose = require('mongoose');
 const supertest = require('supertest');
-// MONGO_URL is provided by @shelf/jest-mongodb
-process.env.DB_URI = process.env.MONGO_URL;
-const { appServer, mongoose } = require('./server');
-const request = supertest(appServer);
 
-afterAll(async () => {
-    await mongoose.disconnect();
-    await appServer.close()
+// MONGO_URL is provided by @shelf/jest-mongodb
+const dbUri = process.env.MONGO_URL;
+const port = 0;
+let request;
+let appServer;
+
+beforeAll (async () => {
+  appServer = await startServer(createApp, dbUri, port);
+  request = supertest(appServer);
+});
+
+afterAll(() => {
+    return Promise.all([mongoose.disconnect(), appServer.close()]);
 });
 
 describe("GET", () => {


### PR DESCRIPTION
`startServer` returns a promise containing the server. `listen` is not called on the server until the db connects. If the promise resolves, the db has connected and the server is ready to handle requests. If the promise rejects, then the server is not ready to handle requests as the db has not been connected.