### PR TITLE
Refactor error handling when db fails to connect

### DIFF
--- a/db-connection.js
+++ b/db-connection.js
@@ -1,13 +1,9 @@
 var mongoose = require('mongoose');
 
-function connectDb (logger, dbUri = process.env.DB_URI) {
+function connectDb(logger, dbUri = process.env.DB_URI) {
     return mongoose.connect(dbUri, { useNewUrlParser: true, useUnifiedTopology: true })
         .then(function () {
             logger.info("DB connected successfully.");
-        })
-        .catch(function (error) {
-            logger.fatal(error, "DB failed to connect.");
-            throw(error);
         });
 }
 

--- a/db-connection.test.js
+++ b/db-connection.test.js
@@ -12,12 +12,7 @@ describe("DB connection", () => {
     const DB_URI = '';
 
     test("fails with invalid uri for db.", () => {
-        expect.assertions(1);
-
-        return connectDb(log, DB_URI)
-            .catch(() => {
-                expect(log.fatal).toBeCalled();
-            });
+        return expect(() => connectDb(log, DB_URI)).rejects.toThrow();
     });
 });
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 'use strict';
+const { logger } = require('./pino');
 const { createApp, startServer } = require('./app');
 
-startServer(createApp);
+startServer(createApp)
+    .catch(err => logger.fatal(err, "Server crash as db failed to connect."));


### PR DESCRIPTION
To keep both the stack trace on the error object and higher level information, error is no longer caught and logged inside the `db-connection` module.