### PR TITLE
Add body parser and new routes for POST and GET, along with testing.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,38 +1,86 @@
 const express = require('express');
-// var mongo = require('mongodb');
 const connectDb = require('./db-connection');
 const { logger } = require('./pino');
 const cors = require('cors');
+const dns = require("dns");
+const util = require("util");
 
-function createApp() {
+function createApp(client) {
+  const db = client.db("shorten_url");
+  const countCollection = db.collection("count");
+  const urlsCollection = db.collection("short_urls");
+
   const app = express();
 
   app.use(cors());
-
-  /** this project needs to parse POST bodies **/
-  // you should mount the body-parser here
-
+  app.use(express.urlencoded({
+    extended: true
+  }));
   app.use('/public', express.static(process.cwd() + '/public'));
 
-  app.get('/', function(req, res){
+  app.get('/', function (req, res) {
     res.sendFile(process.cwd() + '/views/index.html');
   });
-
   app.get("/api/hello", function (req, res) {
-    res.json({greeting: 'hello API'});
+    res.json({ greeting: 'hello API' });
+  });
+  app.get("/api/shorturl/:short_url", async function (req, res, next) {
+    try {
+      const { original_url } = await urlsCollection.findOne({
+        short_url: parseInt(req.params.short_url)
+      });
+      if (original_url) {
+        res.redirect(original_url);
+        return;
+      }
+      // spec does not specify case where short url does not yet exist
+      res.status(404).send("Sorry can't find that!");
+    } catch (err) {
+      // errors can come from the findOne or the redirect calls
+      next(err);
+    }
   });
 
+  app.post("/api/shorturl/new", async function (req, res, next) {
+    const ADDRESS_NOT_FOUND = 'ENOTFOUND';
+    const original_url = req.body.url;
+    const lookup = util.promisify(dns.lookup);
+    try {
+      await lookup(original_url);
+      const updateResults = await countCollection.findOneAndUpdate(
+        { _id: "short_urls" },
+        { $inc: { seq: 1 } },
+        { returnOriginal: false }
+      );
+      const shortened = {
+        original_url,
+        short_url: updateResults.value.seq
+      };
+      await urlsCollection.insertOne(shortened);
+      res.json(shortened);
+    } catch (err) {
+      if (err.code === ADDRESS_NOT_FOUND) {
+        res.json({ error: "invalid URL" });
+        return;
+      }
+      // the err passed to next can come from either
+      // the lookup, the findAndModify, the insert
+      // or res.json
+      next(err);
+    }
+  });
   return app;
 }
 
-function startServer(factory, dbUri, port = process.env.PORT || 3000) {
-  const app = factory();
-  return connectDb(logger, dbUri)
-    .then(() => {
-      return app.listen(port, function () {
-        logger.info('Node.js listening ...');
-      });
-    });
+async function startServer(factory, dbUri, port = process.env.PORT || 3000) {
+  const dbClient = await connectDb(logger, dbUri);
+  const app = factory(dbClient);
+  return {
+    dbClient,
+    app: app.listen(port, function () {
+      logger.info('Node.js listening ...');
+    })
+  };
 }
 
 module.exports = {

--- a/db-connection.js
+++ b/db-connection.js
@@ -1,9 +1,11 @@
-var mongoose = require('mongoose');
+const { MongoClient } = require("mongodb");
 
 function connectDb(logger, dbUri = process.env.DB_URI) {
-    return mongoose.connect(dbUri, { useNewUrlParser: true, useUnifiedTopology: true })
-        .then(function () {
+    const client = new MongoClient(dbUri);
+    return client.connect()
+        .then(() => {
             logger.info("DB connected successfully.");
+            return client;
         });
 }
 

--- a/db-connection.test.js
+++ b/db-connection.test.js
@@ -1,5 +1,4 @@
 const connectDb = require('./db-connection');
-const mongoose = require('mongoose');
 
 // logger stub with spies
 const log = {
@@ -18,13 +17,16 @@ describe("DB connection", () => {
 describe("DB connection", () => {
     // MONGO_URL is provided by @shelf/jest-mongodb
     const DB_URI = process.env.MONGO_URL;
-
+    let client;
     afterAll(() => {
-        return mongoose.disconnect();
+        return client.close();
     });
 
     test("is succesful.", () => {
         return connectDb(log, DB_URI)
-            .then(() => expect(log.info).toBeCalled());
+            .then(connectedClient => {
+                client = connectedClient;
+                expect(log.info).toBeCalled()
+            });
     });
 });

--- a/server.test.js
+++ b/server.test.js
@@ -1,27 +1,85 @@
 const { createApp, startServer } = require('./app');
-const mongoose = require('mongoose');
 const supertest = require('supertest');
 
 // MONGO_URL is provided by @shelf/jest-mongodb
 const dbUri = process.env.MONGO_URL;
 const port = 0;
 let request;
-let appServer;
+let app;
+let dbClient;
 
-beforeAll (async () => {
-  appServer = await startServer(createApp, dbUri, port);
-  request = supertest(appServer);
+beforeAll(async () => {
+  ({ app, dbClient } = await startServer(createApp, dbUri, port));
+  request = supertest(app);
+
+  // seed count db to start sequencing of short urls at 0
+  const countCollection = dbClient
+    .db("shorten_url")
+    .collection("count");
+  await countCollection.insertOne({
+    _id: "short_urls",
+    seq: 0
+  });
 });
 
 afterAll(() => {
-    return Promise.all([mongoose.disconnect(), appServer.close()]);
+  return Promise.all([dbClient.close(), app.close()]);
 });
 
 describe("GET", () => {
   test("/api/hello", async () => {
-    const response = await request.get("/api/hello");
+    const response = await request
+      .get("/api/hello")
+      .set("Accept", "application/json");
 
     expect(response.status).toBe(200);
     expect(response.body.greeting).toBe("hello API");
+  });
+});
+
+describe("Adding urls", () => {
+  test("for url that passes dns lookup.", async () => {
+    const url = 'www.google.ca';
+    const response = await request
+      .post("/api/shorturl/new")
+      .send(`url=${url}`)
+      .set("Accept", "application/json");
+
+    expect(response.status).toBe(200);
+    expect(response.body.original_url).toBe(url);
+    expect(typeof response.body.short_url).toBe('number');
+  });
+
+  test("for url that fails dns lookup.", async () => {
+    const url = 'http://www.google.ca/non-existent';
+    const response = await request
+      .post("/api/shorturl/new")
+      .send(`url=${url}`)
+      .set("Accept", "application/json");
+
+    expect(response.status).toBe(200);
+    expect(response.body.error).toBe("invalid URL");
+  })
+});
+
+describe("Getting urls", () => {
+  test("for short url that's been added.", async () => {
+    const url = "www.google.ca";
+    const addResponse = await request
+      .post("/api/shorturl/new")
+      .send(`url=${url}`);
+
+    const response = await request
+      .get(`/api/shorturl/${addResponse.body.short_url}`);
+
+    expect(response.status).toBe(302);
+    expect(response.text).toBe(`Found. Redirecting to ${url}`);
+  });
+
+  test("for short url that has not been added.", async () => {
+    const response = await request
+      .get('/api/short/url/1000000');
+
+    expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
There are two ways to make an [auto-incrementing sequence field](https://docs.mongodb.com/v3.0/tutorial/create-an-auto-incrementing-field/) in mongoDB, and the counters collection is implemented using the non-deprecated calls to the db. The counters collection does constitute a [bottle-neck](https://www.mongodb.com/blog/post/generating-globally-unique-identifiers-for-use-with-mongodb) and will affect performance; however, it _is_ easier to implement. 

The counts collection has been seeded in production. For every integration and unit test, the in-memory db will have to be seeded with a starting sequence of 0 beforehand.