### PR TITLE
Add timer to keep process alive long enough for db to connect.

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,3 +5,5 @@ const { createApp, startServer } = require("./app");
 startServer(createApp).catch((err) =>
   logger.fatal(err, "Server crash as db failed to connect.")
 );
+
+setInterval(function () { }, 60000);


### PR DESCRIPTION
The time lasts 60,000 milliseconds, which allows for the db to retry.